### PR TITLE
Expand-Property vs -ExpandProperty

### DIFF
--- a/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
+++ b/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
@@ -256,7 +256,7 @@ Process {
 	switch -Wildcard ($ComputerManufacturer) {
 		"*Microsoft*" {
 			$ComputerManufacturer = "Microsoft"
-			$ComputerModel = Get-WmiObject -Namespace root\wmi -Class MS_SystemInformation | Select-Object Expand-Property SystemSKU
+			$ComputerModel = Get-WmiObject -Namespace root\wmi -Class MS_SystemInformation | Select-Object -ExpandProperty SystemSKU
 		}
 		"*HP*" {
 			$ComputerManufacturer = "Hewlett-Packard"


### PR DESCRIPTION
The "-" was in the wrong spot on -ExpandProperty to select the Microsoft SystemSku