### PR TITLE
Update Invoke-CMDownloadBIOSPackage.ps1

### DIFF
--- a/Operating System Deployment/BIOS/Invoke-CMDownloadBIOSPackage.ps1
+++ b/Operating System Deployment/BIOS/Invoke-CMDownloadBIOSPackage.ps1
@@ -398,7 +398,7 @@ Process {
 				if ($Package.PackageManufacturer -ne $null) {
 					# Match model, manufacturer criteria
 					if ($Manufacturers -contains $ComputerManufacturer) {
-						if (($Package.PackageDescription -match $SystemSKU) -and ($ComputerManufacturer -match $Package.PackageManufacturer)) {
+						if (($Package.PackageName -like "*${SystemSKU}") -and ($ComputerManufacturer -match $Package.PackageManufacturer)) {
 							Write-CMLogEntry -Value "Match found for computer model and manufacturer: $($Package.PackageName) ($($Package.PackageID))" -Severity 1
 							$PackageList.Add($Package) | Out-Null
 						}


### PR DESCRIPTION
Change conditional operator when looking for package matches against a computer model. This is because Dell has model names like 'OptiPlex 9020' and 'OptiPlex 9020 AIO' which will both match if BIOS packages have been downloaded for both models and a computer that is an OptiPlex 9020 runs this script. By checking against the PackageName and using a wildcard at the beginning with a like operator instead of a match, this should help an OptiPlex 9020 not return a result for the 9020 AIO.