### PR TITLE
Update Invoke-CMDownloadBIOSPackage.ps1

### DIFF
--- a/Operating System Deployment/BIOS/Invoke-CMDownloadBIOSPackage.ps1
+++ b/Operating System Deployment/BIOS/Invoke-CMDownloadBIOSPackage.ps1
@@ -349,6 +349,10 @@ Process {
 			$ComputerManufacturer = "Dell"
 			$ComputerModel = Get-WmiObject -Class Win32_ComputerSystem | Select-Object -ExpandProperty Model
 			$SystemSKU = (Get-CIMInstance -ClassName MS_SystemInformation -NameSpace root\WMI).SystemSku
+			# some Dell computer systems return empty $systemSKU. If that happens, just set the SystemSKU to the Model
+			if (-not $SystemSKU) {
+				$SystemSKU = $ComputerModel
+			}
 		}
 		"*Lenovo*" {
 			$ComputerManufacturer = "Lenovo"

--- a/Operating System Deployment/BIOS/Invoke-CMDownloadBIOSPackage.ps1
+++ b/Operating System Deployment/BIOS/Invoke-CMDownloadBIOSPackage.ps1
@@ -398,12 +398,28 @@ Process {
 				if ($Package.PackageManufacturer -ne $null) {
 					# Match model, manufacturer criteria
 					if ($Manufacturers -contains $ComputerManufacturer) {
-						if (($Package.PackageDescription -match $SystemSKU) -and ($ComputerManufacturer -match $Package.PackageManufacturer)) {
-							Write-CMLogEntry -Value "Match found for computer model and manufacturer: $($Package.PackageName) ($($Package.PackageID))" -Severity 1
-							$PackageList.Add($Package) | Out-Null
+						if ($ComputerManufacturer -eq 'Dell') {
+							# below we look for a regex matching a 4-character alphanumeric string (some Dell systems return something like 05A4 as their SystemSKU)
+							if (($SystemSKU -match "^(?=.{4}$)[a-zA-Z0-9]*$") -and ($Package.PackageDescription -match $SystemSKU) -and ($ComputerManufacturer -match $Package.PackageManufacturer)) {
+								Write-CMLogEntry -Value "Match found for computer model and manufacturer: $($Package.PackageName) ($($Package.PackageID))" -Severity 1
+								$PackageList.Add($Package) | Out-Null
+							}
+							elseif (($Package.PackageName -like "*${SystemSKU}") -and ($ComputerManufacturer -match $Package.PackageManufacturer)) {
+								Write-CMLogEntry -Value "Match found for computer model and manufacturer: $($Package.PackageName) ($($Package.PackageID))" -Severity 1
+								$PackageList.Add($Package) | Out-Null
+							}
+							else {
+								Write-CMLogEntry -Value "Package does not meet computer model and manufacturer criteria: $($Package.PackageName) ($($Package.PackageID))" -Severity 2
+							}
 						}
 						else {
-							Write-CMLogEntry -Value "Package does not meet computer model and manufacturer criteria: $($Package.PackageName) ($($Package.PackageID))" -Severity 2
+							if (($Package.PackageDescription -match $SystemSKU) -and ($ComputerManufacturer -match $Package.PackageManufacturer)) {
+							Write-CMLogEntry -Value "Match found for computer model and manufacturer: $($Package.PackageName) ($($Package.PackageID))" -Severity 1
+							$PackageList.Add($Package) | Out-Null
+							}
+							else {
+								Write-CMLogEntry -Value "Package does not meet computer model and manufacturer criteria: $($Package.PackageName) ($($Package.PackageID))" -Severity 2
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Adjusted conditional logic inside foreach loop to see if packagedescription's match SystemSKU. The issue on Dell systems is that some return a SystemSKU similar to "OptiPlex 9020", some return a SystemSKU of "05A4" (even though it may also be an OptiPlex 9020), and some similar models return a SystemSKU of "OptiPlex 9020 AIO." 

Tried to fix the issue where current conditional logic will return SCCM Packages for both "OptiPlex 9020" AND "OptiPlex 9020 AIO." I did it by adding a regex to look for a 4-character alphanumeric string in SystemSKU first. If it matches that regex, then search using the PackageDescription. Otherwise, do a wildcard match against the PackageName to catch the Dell Model number which usually appears at the very end.

Since I only had Dell machines to test against, I didn't want to alter the current conditional logic of other MFRs like HP, Lenovo, and Microsoft, so I separated out their conditional checks from these new ones. 

I'm not entirely happy with violating the DRY principle, but it fixed the immediate model identification issue I was having. Perhaps someone can think of a smarter way of implementing this same check.