### PR TITLE
HP .split() problem solved

### DIFF
--- a/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
+++ b/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
@@ -441,6 +441,13 @@ Process {
 		}
 	}
 
+	if ($ComputerModel -like "HP*")
+		{
+
+    		$ComputerModel = $ComputerModel -replace "HP*", "Hewlett-Packard"
+    
+		}
+
 	Write-CMLogEntry -Value "Manufacturer determined as: $($ComputerManufacturer)" -Severity 1
 	Write-CMLogEntry -Value "Computer model determined as: $($ComputerModel)" -Severity 1
 	if (-not ([string]::IsNullOrEmpty($SystemSKU))) {
@@ -533,9 +540,17 @@ Process {
 						$ComputerDetectionResult = $false
 						switch ($ComputerDetectionMethod) {
 							"ComputerModel" {
-								if ($Package.PackageName.Split("-").Replace($ComputerManufacturer, "").Trim()[1] -match $ComputerModel) {
-									Write-CMLogEntry -Value "Match found for computer model using detection method: $($ComputerDetectionMethod) ($($ComputerModel))" -Severity 1
-									$ComputerDetectionResult = $true
+								if ($ComputerManufacturer -eq "Hewlett-Packard") {
+									if ($package.PackageName.Replace($ComputerManufacturer, "HP").Split('-').Replace("HP", $ComputerManufacturer).Trim()[1] -match $ComputerModel) {
+										Write-CMLogEntry -Value "Match found for computer model using detection method: $($ComputerDetectionMethod) ($($ComputerModel))" -Severity 1
+										$ComputerDetectionResult = $true
+									}
+								}
+								else {
+									if ($Package.PackageName.Split("-").Replace($ComputerManufacturer, "").Trim()[1] -match $ComputerModel) {
+										Write-CMLogEntry -Value "Match found for computer model using detection method: $($ComputerDetectionMethod) ($($ComputerModel))" -Severity 1
+										$ComputerDetectionResult = $true
+									}
 								}
 							}
 							"SystemSKU" {
@@ -596,9 +611,17 @@ Process {
 
 							# Process driver package list in reverse
 							for ($i = ($PackageList.Count-1); $i -ge 0; $i--) {
-								if ($PackageList[$i].PackageName.Split("-").Replace($ComputerManufacturer, "").Trim()[1] -notmatch $ComputerModel) {
+								if ($ComputerManufacturer -eq "Hewlett-Packard") {
+									if ($PackageList[$i].PackageName.Replace($ComputerManufacturer, "HP").Split('-').Replace("HP", $ComputerManufacturer).Trim()[1] -notmatch $ComputerModel) {
 									Write-CMLogEntry -Value "Removing driver package matching SystemSKU but not computer model: $($PackageList[$i].PackageName)" -Severity 1
 									$PackageList.RemoveAt($i)
+									}
+								}
+								else {
+									if ($PackageList[$i].PackageName.Split("-").Replace($ComputerManufacturer, "").Trim()[1] -notmatch $ComputerModel) {
+									Write-CMLogEntry -Value "Removing driver package matching SystemSKU but not computer model: $($PackageList[$i].PackageName)" -Severity 1
+									$PackageList.RemoveAt($i)
+									}
 								}
 							}
 						}

--- a/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
+++ b/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
@@ -84,6 +84,7 @@
 	2.0.6 - (2018-02-21) Updated to cater for the presence of underscores in Microsoft Surface models
 	2.0.7 - (2018-02-25) Added support for a DebugMode switch for running script outside of a task sequence for driver package detection
 	2.0.8 - (2018-02-25) Added a check to bail out the script if computer model and SystemSKU are null or an empty string
+	2.0.9 - (2018-05-03) Added fix so HP/Hewlett-Packard models can correctly be matched based on $ComputerModel
 #>
 [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = "Execute")]
 param (


### PR DESCRIPTION
Based on issue #46 .
HP .Split() problem solved. HP/Hewlett-Packard models can now correctly being matched based on $ComputerModel.

Issues solved:

1. All driver packages within ConfigManager imported by the Driver Automation Tool are named 'Drivers - Hewlett-Packard [...]'. Some models are identified as 'HP EliteBook 840 G3', with $computermanufacturer 'Hewlett-Packard' for example. 
When comparing $computermanufacturer and $package.PackageName in this case will not result in a $true, since 'HP' and 'Hewlett-Packard' don't match.

2. **$ComputerDetectionMethod = $ComputerModel** 
To compare the $computermanufacturer and $package.PackageName strings, the $package.PackageName string is first split based on the '-' character. Since 'Hewlett-Packard' also contains this character, the split will not return the desired result (as described in issue #46 ).
By temporarily changing "Hewlett-Packard" to "HP", the split will return the desired results. Afterwards, "HP" is changed back to "Hewlett-Packard" again to do the matching bit.  

3. **$ComputerDetectionMethod = $SystemSKU**
Like the situation as described above, when the $systemsku method returns more than one possible match, the script isn't able to match that to one single package based on $ComputerModel. 
To compare the $computermanufacturer and $package.PackageName strings, the $package.PackageName string is first split based on the '-' character. Since 'Hewlett-Packard' also contains this character, the split will not return the desired result (as described in issue #46 ).
By temporarily changing "Hewlett-Packard" to "HP", the split will return the desired results. Afterwards, "HP" is changed back to "Hewlett-Packard" again to do the matching bit.  

