### PR TITLE
Update Invoke-CMApplyDriverPackage.ps1

### DIFF
--- a/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
+++ b/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
@@ -265,13 +265,17 @@ Process {
 		try {
 			Write-CMLogEntry -Value "Starting package content download process, this might take some time" -Severity 1
 			
-			if (-not $TSEnvironment.Value("_SMSTSInWinPE") -eq 'true') {
+			if ($TSEnvironment.Value("_SMSTSInWinPE") -eq 'true') {
+				Write-CMLogEntry -Value "Starting package content download process (WinPE), this might take some time" -Severity 1
+				$ReturnCode = Invoke-Executable -FilePath "OSDDownloadContent.exe"
+			}
+			elseif (Test-Path 'C:\Windows\CCM\OSDDownloadContent.exe'){
 				Write-CMLogEntry -Value "Starting package content download process (FullOS), this might take some time" -Severity 1
 				$ReturnCode = Invoke-Executable -FilePath "C:\Windows\CCM\OSDDownloadContent.exe"
 			}
 			else {
-				Write-CMLogEntry -Value "Starting package content download process (WinPE), this might take some time" -Severity 1
-				$ReturnCode = Invoke-Executable -FilePath "OSDDownloadContent.exe"
+				Write-CMLogEntry -Value "Unable to determine whether in WinPE or full OS. Defaulting to FullOS but this may fail." -Severity 2;
+				$ReturnCode = Invoke-Executable -FilePath "C:\Windows\CCM\OSDDownloadContent.exe"
 			}
 			
 			# Match on return code

--- a/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
+++ b/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
@@ -265,7 +265,7 @@ Process {
 		try {
 			Write-CMLogEntry -Value "Starting package content download process, this might take some time" -Severity 1
 			
-			if (Test-Path -Path "C:\Windows\CCM\OSDDownloadContent.exe") {
+			if (-not $TSEnvironment.Value("_SMSTSInWinPE") -eq 'true') {
 				Write-CMLogEntry -Value "Starting package content download process (FullOS), this might take some time" -Severity 1
 				$ReturnCode = Invoke-Executable -FilePath "C:\Windows\CCM\OSDDownloadContent.exe"
 			}


### PR DESCRIPTION
Inside Invoke-CMDownloadContent function, changed conditional to check for _SMSTSInWinPE TS variable rather than the existence of c:\windows\ccm\osddownloadcontent.exe. The latter path can exist even when inside WinPE when reimaging a computer that already had Windows/CCM client on it, and can cause the TS to fail when DLLs for the OSDDownloadContent executable can't be properly loaded. Due to this error, I was getting "package content download process failed 1073741511" as a return error from the Invoke-CMDownloadContent function.