### PR TITLE
Update Invoke-CMApplyDriverPackage.ps1

### DIFF
--- a/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
+++ b/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
@@ -662,12 +662,12 @@ Process {
 									Write-CMLogEntry -Value "Driver package list contains multiple matches, attempting to download driver package content based up latest package creation date" -Severity 1
 									
 									# Determine matching driver package from array list with vendor specific solutions
-									if (($ComputerManufacturer -like "Hewlett-Packard") -and ($OSName -like "Windows 10") -and $PSBoundParameters.ContainsKey("UseLatestHPWindows10DP")) {
-										$Package = $PackageList | Sort-Object -Property PackageCreated -Descending | Select-Object -First 1
-									}
-                                    					elseif (($ComputerManufacturer -like "Hewlett-Packard") -and ($OSName -like "Windows 10")) {
+									if (($ComputerManufacturer -like "Hewlett-Packard") -and ($OSName -like "Windows 10")) {
 										Write-CMLogEntry -Value "Vendor specific matching required before downloading content. Attempting to match $($ComputerManufacturer) driver package based on OS build number: $($OSImageVersion)" -Severity 1
 										$Package = ($PackageList | Where-Object { $_.PackageName -match ([System.Version]$OSImageVersion).Build }) | Sort-Object -Property PackageCreated -Descending | Select-Object -First 1
+									}
+                                    					elseif (($ComputerManufacturer -like "Hewlett-Packard") -and ($OSName -like "Windows 10") -and $PSBoundParameters.ContainsKey("UseLatestHPWindows10DP")) {
+										$Package = $PackageList | Sort-Object -Property PackageCreated -Descending | Select-Object -First 1
 									}
 									else {
 										$Package = $PackageList | Sort-Object -Property PackageCreated -Descending | Select-Object -First 1

--- a/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
+++ b/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
@@ -662,12 +662,12 @@ Process {
 									Write-CMLogEntry -Value "Driver package list contains multiple matches, attempting to download driver package content based up latest package creation date" -Severity 1
 									
 									# Determine matching driver package from array list with vendor specific solutions
-									if (($ComputerManufacturer -like "Hewlett-Packard") -and ($OSName -like "Windows 10")) {
+									if (($ComputerManufacturer -like "Hewlett-Packard") -and ($OSName -like "Windows 10") -and $PSBoundParameters.ContainsKey("UseLatestHPWindows10DP")) {
+										$Package = $PackageList | Sort-Object -Property PackageCreated -Descending | Select-Object -First 1
+									}
+                                    					elseif (($ComputerManufacturer -like "Hewlett-Packard") -and ($OSName -like "Windows 10")) {
 										Write-CMLogEntry -Value "Vendor specific matching required before downloading content. Attempting to match $($ComputerManufacturer) driver package based on OS build number: $($OSImageVersion)" -Severity 1
 										$Package = ($PackageList | Where-Object { $_.PackageName -match ([System.Version]$OSImageVersion).Build }) | Sort-Object -Property PackageCreated -Descending | Select-Object -First 1
-									}
-                                    					elseif (($ComputerManufacturer -like "Hewlett-Packard") -and ($OSName -like "Windows 10") -and $PSBoundParameters.ContainsKey("UseLatestHPWindows10DP")) {
-										$Package = $PackageList | Sort-Object -Property PackageCreated -Descending | Select-Object -First 1
 									}
 									else {
 										$Package = $PackageList | Sort-Object -Property PackageCreated -Descending | Select-Object -First 1


### PR DESCRIPTION
HP does not provide updated driver packs for _every_ family of models for every new build of Windows 10. Adding the optional parameter **-UseLatestHPWindows10DP** will optionally allow using a Windows 10 driver pack from HP that was released for an older build of Windows 10 instead of not applying a driver pack at all.

Feel free to change the parameter name if you would prefer something else. I'm not completely sold on the name I used ;)

Reference: http://ftp.hp.com/pub/caps-softpaq/cmit/HP_Driverpack_Matrix_x64.html