### PR TITLE
Invalid TimezoneBias

### DIFF
--- a/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
+++ b/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
@@ -204,7 +204,7 @@ Process {
 			If ($TimezoneBias -match "^-") {$TimezoneBias = $TimezoneBias.Replace('-', '+')# flip the offset value from negative to positive
 			} else {$TimezoneBias = '-' + $TimezoneBias }
 		}
-		$Time = -join @((Get-Date -Format "HH:mm:ss.fff"), $TimezoneBias #"+", (Get-WmiObject -Class Win32_TimeZone | Select-Object -ExpandProperty Bias))
+		$Time = -join @((Get-Date -Format "HH:mm:ss.fff"), $TimezoneBias) #"+", (Get-WmiObject -Class Win32_TimeZone | Select-Object -ExpandProperty Bias))
 		
 		# Construct date for log entry
 		$Date = (Get-Date -Format "MM-dd-yyyy")

--- a/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
+++ b/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
@@ -199,7 +199,12 @@ Process {
 		$LogFilePath = Join-Path -Path $LogsDirectory -ChildPath $FileName
 		
 		# Construct time stamp for log entry
-		$Time = -join @((Get-Date -Format "HH:mm:ss.fff"), "+", (Get-WmiObject -Class Win32_TimeZone | Select-Object -ExpandProperty Bias))
+		If (-not(Test-Path -Path 'variable:global:TimezoneBias')) {
+			[string]$global:TimezoneBias = [System.TimeZoneInfo]::Local.GetUtcOffset((Get-Date)).TotalMinutes
+			If ($TimezoneBias -match "^-") {$TimezoneBias = $TimezoneBias.Replace('-', '+')# flip the offset value from negative to positive
+			} else {$TimezoneBias = '-' + $TimezoneBias }
+		}
+		$Time = -join @((Get-Date -Format "HH:mm:ss.fff"), $TimezoneBias #"+", (Get-WmiObject -Class Win32_TimeZone | Select-Object -ExpandProperty Bias))
 		
 		# Construct date for log entry
 		$Date = (Get-Date -Format "MM-dd-yyyy")


### PR DESCRIPTION
Address issue where a negative TimezoneBias would generate a timestamp like "12:13:14.567+-360".  The "+-" causes CMTrace to not display the timestamp.  The issue appears in the Modern BIOS Management scripts as well.