### PR TITLE
Update Invoke-HPBIOSUpdate Password.bin file location

### DIFF
--- a/Operating System Deployment/BIOS/Invoke-HPBIOSUpdate.ps1
+++ b/Operating System Deployment/BIOS/Invoke-HPBIOSUpdate.ps1
@@ -159,7 +159,7 @@ Process {
 	
 	if (-not([System.String]::IsNullOrEmpty($PasswordBin))) {
 		# Add password to the flash bios switches
-		$FlashSwitches = $FlashSwitches + " -p$($Path)\$($PasswordBin)"	
+		$FlashSwitches = $FlashSwitches + " -p$($PSScriptRoot)\$($PasswordBin)"	
 		Write-CMLogEntry -Value "Using the following switches for BIOS file: $($FlashSwitches)" -Severity 1
 	}
 	else {


### PR DESCRIPTION
Changed location to where the password.bin file is located. To the Script folder instead of the BIOS Package. Changes made due to updating failed, since it couldn't find the password-bin file in the BIOS packages.