### PR TITLE
Update Invoke-CMApplyDriverPackage.ps1

### DIFF
--- a/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
+++ b/Operating System Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1
@@ -407,10 +407,16 @@ Process {
 									OSVersion  = $OSImage.Version
 									OSArchitecture = $OSImage.Architecture
 								}
-
-								# Handle return value
-								return $PSObject
 							}
+						}
+						
+						# Test if the PSCustomObject is filled
+						if ($null -eq $PsObject) {
+							Write-CMLogEntry -Value "The provided package id '$($OSImageTsVariableValue)' from the task sequence variable '$($OSImageTSVariableName)' does not belong to a valid operating system image package." -Severity 3
+							exit 4
+						} else {
+							# Handle return value
+							return $PSObject
 						}
 					}
 					else {


### PR DESCRIPTION
## Bug Description
If a wrong package id (which is not a operating system image package) is defined in the task sequence variable `OSImagePackageId` the script failed with the following error during an OSD tasksequence:  
**Snippet from smsts.log**
```
<![LOG[CommandLine: '"X:\WINDOWS\system32\windowspowershell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "& 'C:\_SMSTaskSequence\Packages\P0100059\Invoke-CMApplyDriverPackage.ps1' -URI "http://<FQDN PrimarySiteServer>/ConfigMgrWebService/ConfigMgr.asmx" -SecretKey "<MYSECRETKEY>" -Filter "Drivers" -OSImageTSVariableName OSImagePackageId ; exit ($LASTEXITCODE -bor [int](-not $? -and -not $LASTEXITCODE)) "']LOG]!><time="11:08:18.081-60" date="11-04-2019" component="RunPowerShellScript" context="" type="1" thread="1476" file="main.cpp:462">
<![LOG[Executing command line: Run PowerShell Script with options (0, 4)]LOG]!><time="11:08:18.081-60" date="11-04-2019" component="RunPowerShellScript" context="" type="0" thread="1476" file="CommandLine.cpp:822">
<![LOG[Process completed with exit code 1]LOG]!><time="11:08:32.784-60" date="11-04-2019" component="RunPowerShellScript" context="" type="0" thread="1476" file="CommandLine.cpp:1136">
<![LOG[C:\_SMSTaskSequence\Packages\P0100059\Invoke-CMApplyDriverPackage.ps1 : Cannot validate argument on parameter ]LOG]!><time="11:08:32.784-60" date="11-04-2019" component="RunPowerShellScript" context="" type="3" thread="1476" file="main.cpp:67">
<![LOG['InputObject'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command ]LOG]!><time="11:08:32.784-60" date="11-04-2019" component="RunPowerShellScript" context="" type="3" thread="1476" file="main.cpp:67">
<![LOG[again.]LOG]!><time="11:08:32.784-60" date="11-04-2019" component="RunPowerShellScript" context="" type="3" thread="1476" file="main.cpp:67">
<![LOG[At line:1 char:1]LOG]!><time="11:08:32.784-60" date="11-04-2019" component="RunPowerShellScript" context="" type="3" thread="1476" file="main.cpp:67">
<![LOG[+ & 'C:\_SMSTaskSequence\Packages\P0100059\Invoke-CMApplyDriverPackage. ...]LOG]!><time="11:08:32.785-60" date="11-04-2019" component="RunPowerShellScript" context="" type="3" thread="1476" file="main.cpp:67">
<![LOG[+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]LOG]!><time="11:08:32.785-60" date="11-04-2019" component="RunPowerShellScript" context="" type="3" thread="1476" file="main.cpp:67">
<![LOG[    + CategoryInfo          : InvalidData: (:) [Invoke-CMApplyDriverPackage.ps1], ParameterBindingValidationException]LOG]!><time="11:08:32.785-60" date="11-04-2019" component="RunPowerShellScript" context="" type="3" thread="1476" file="main.cpp:67">
<![LOG[    + FullyQualifiedErrorId : ParameterArgumentValidationError,Invoke-CMApplyDriverPackage.ps1]LOG]!><time="11:08:32.785-60" date="11-04-2019" component="RunPowerShellScript" context="" type="3" thread="1476" file="main.cpp:67">
<![LOG[ ]LOG]!><time="11:08:32.785-60" date="11-04-2019" component="RunPowerShellScript" context="" type="3" thread="1476" file="main.cpp:67">
<![LOG[PowerShell command line returned code 1]LOG]!><time="11:08:32.785-60" date="11-04-2019" component="RunPowerShellScript" context="" type="1" thread="1476" file="main.cpp:475">
```

**ApplyDriverPackage.log**
```
<![LOG[===== SCConfigMgr Invoke-CMApplyDriverPackage Version 2.2.3 ====]LOG]!><time="11:08:20.230-60" date="11-04-2019" component="ApplyDriverPackage" context="NT AUTHORITY\SYSTEM" type="1" thread="2328" file="">
<![LOG[Driver download package process initiated]LOG]!><time="11:08:20.27260" date="11-04-2019" component="ApplyDriverPackage" context="NT AUTHORITY\SYSTEM" type="1" thread="2328" file="">
<![LOG[Manufacturer determined as: Hewlett-Packard]LOG]!><time="11:08:20.59660" date="11-04-2019" component="ApplyDriverPackage" context="NT AUTHORITY\SYSTEM" type="1" thread="2328" file="">
<![LOG[Computer model determined as: HP EliteBook 840 G5]LOG]!><time="11:08:20.59760" date="11-04-2019" component="ApplyDriverPackage" context="NT AUTHORITY\SYSTEM" type="1" thread="2328" file="">
<![LOG[Computer SKU determined as: 83B2]LOG]!><time="11:08:20.60060" date="11-04-2019" component="ApplyDriverPackage" context="NT AUTHORITY\SYSTEM" type="1" thread="2328" file="">
<![LOG[Retrieved a total of 6 driver packages from web service]LOG]!><time="11:08:26.96160" date="11-04-2019" component="ApplyDriverPackage" context="NT AUTHORITY\SYSTEM" type="1" thread="2328" file="">
<![LOG[Attempting to detect OS Image data from task sequence, running in DeploymentType: BareMetal]LOG]!><time="11:08:26.98160" date="11-04-2019" component="ApplyDriverPackage" context="NT AUTHORITY\SYSTEM" type="1" thread="2328" file="">
<![LOG[Multiple OS Image objects detected. Objects will be matched against provided task sequence variable name 'OSImagePackageId' to determine the correct object]LOG]!><time="11:08:32.52960" date="11-04-2019" component="ApplyDriverPackage" context="NT AUTHORITY\SYSTEM" type="1" thread="2328" file="">

```

## Root Cause
The function `Get-OSImageData` does not validate if the given PackageId is a valid Operating System Image package.  
If the PackageId is not an Operating System Image package, the function does not return anything.
This results in an `ParameterArgumentValidationError` exception when the script runs the following line ([Line 654](https://github.com/Wav3/ConfigMgr/blob/45bbab77308328d0a955b8d1f30719bf1623a481/Operating%20System%20Deployment/Drivers/Invoke-CMApplyDriverPackage.ps1#L654)):
```powershell
$OSDetails = Get-OSDetails -InputObject $OSImageVersion
```

## Solution Description
The function `Get-OSImageData` now perform a check if the variable `$PSCustomObject` is null when trying to select the OS Image matching the value in the task sequence variable `OSImageTsVariableName`.  
If the value is null, a log entry is created and the script exits with the exit code 4.